### PR TITLE
fix: add missing peer dependency `jscodeshift`

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,5 @@
+enableGlobalCache: false
+
 immutablePatterns:
   - .pnp.*
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
   "dependencies": {
     "jscodeshift-add-imports": "^1.0.7"
   },
+  "peerDependencies": {
+    "jscodeshift": "^0.11.0"
+  },
   "devDependencies": {
     "@jest/types": "^26.3.0",
     "@rollup/plugin-commonjs": "^15.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3214,6 +3214,8 @@ __metadata:
     ts-jest: ^26.3.0
     tslib: ^2.0.1
     typescript: ^4.0.2
+  peerDependencies:
+    jscodeshift: ^0.11.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

`jscodeshift-add-imports` has an unmet peer dependency on `jscodeshift`

**How did you fix it?**

Added `jscodeshift` as a peer dependency